### PR TITLE
Set AffectsSavedGames = 0 in modinfo properties

### DIFF
--- a/ProductionQueue.modinfo
+++ b/ProductionQueue.modinfo
@@ -6,6 +6,7 @@
 		<Teaser>Add production queues to cities.</Teaser>
 		<Authors>Lozenged</Authors>
 		<CompatibleVersions>2.0</CompatibleVersions>
+		<AffectsSavedGames>0</AffectsSavedGames>
 	</Properties>
     <Components>
         <ImportFiles id="PRODUCTION_QUEUE_IMPORT_FILES">


### PR DESCRIPTION
This mod does not affect saved games, so set this option to avoid forcing use of this mod when loading saved games.